### PR TITLE
ability to set default extensions

### DIFF
--- a/bin/lr-http-server
+++ b/bin/lr-http-server
@@ -14,6 +14,7 @@ program
   .option('-l, --livereload <portNumber>', 'Port for the livereload server. Disabled if `false`')
   .option('-w, --watchFiles <paths>', 'Comma-separated list of glob patterns of files to watch', list)
   .option('-b, --disableBrowserOpen', 'Disable opening a browser window on the server root')
+  .option('-e, --extensions <exts>', 'Comma-separeted list of extensions which will be added to file name if the file not found (think like /foo -> /foo.html)', list)
   .parse(process.argv);
 
-simpleHttpMime(program.port, program.dir, program.url, program.livereload, program.watchFiles, !program.disableBrowserOpen);
+simpleHttpMime(program.port, program.dir, program.url, program.livereload, program.watchFiles, !program.disableBrowserOpen, program.extensions);

--- a/bin/lr-http-server
+++ b/bin/lr-http-server
@@ -14,7 +14,7 @@ program
   .option('-l, --livereload <portNumber>', 'Port for the livereload server. Disabled if `false`')
   .option('-w, --watchFiles <paths>', 'Comma-separated list of glob patterns of files to watch', list)
   .option('-b, --disableBrowserOpen', 'Disable opening a browser window on the server root')
-  .option('-e, --extensions <exts>', 'Comma-separeted list of extensions which will be added to file name if the file not found (think like /foo -> /foo.html)', list)
+  .option('-e, --extensions <exts>', 'Comma-separated list of extensions which will be added to file name if the file not found (think like /foo -> /foo.html)', list)
   .parse(process.argv);
 
 simpleHttpMime(program.port, program.dir, program.url, program.livereload, program.watchFiles, !program.disableBrowserOpen, program.extensions);

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ var connect = require('connect'),
 
 
 
-module.exports = function(port, dir, url, livereloadPort, watchFiles, openBrowser) {
+module.exports = function(port, dir, url, livereloadPort, watchFiles, openBrowser, extensions) {
 
   port = port || 8080;
   dir = dir || '.';
@@ -21,6 +21,7 @@ module.exports = function(port, dir, url, livereloadPort, watchFiles, openBrowse
 
   watchFiles = watchFiles || [ '**/*.html', '**/*.js', '**/*.css', '**/*.xml' ];
 
+  extensions = extensions.length ? extensions : false;
 
   absoluteDir = path.resolve(dir);
 
@@ -63,7 +64,7 @@ module.exports = function(port, dir, url, livereloadPort, watchFiles, openBrowse
     });
   }
 
-  server.use(serveStatic(absoluteDir))
+  server.use(serveStatic(absoluteDir, { extensions: extensions }))
         .use(serveIndex(absoluteDir))
         .listen(port);
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ module.exports = function(port, dir, url, livereloadPort, watchFiles, openBrowse
 
   watchFiles = watchFiles || [ '**/*.html', '**/*.js', '**/*.css', '**/*.xml' ];
 
-  extensions = extensions.length ? extensions : false;
+  extensions = extensions.length > 0 ? extensions : false;
 
   absoluteDir = path.resolve(dir);
 


### PR DESCRIPTION
Hey, 

I added a small feature  to set the default extension to be used when serving files, it can be really useful if you have a file named `foo.html` and you want it show when you try to open `/foo`, not just when you type `/foo.html` in your browser.

Thankfully `serve-static` does already support this feature.