### PR TITLE
debounce file changes so they can be grouped

### DIFF
--- a/bin/lr-http-server
+++ b/bin/lr-http-server
@@ -14,6 +14,7 @@ program
   .option('-l, --livereload <portNumber>', 'Port for the livereload server. Disabled if `false`')
   .option('-w, --watchFiles <paths>', 'Comma-separated list of glob patterns of files to watch', list)
   .option('-b, --disableBrowserOpen', 'Disable opening a browser window on the server root')
+  .option('-D, --debounce-delay <n>', 'The applied delay for file watching in milliseconds, it can be used for grouping changes')
   .parse(process.argv);
 
-simpleHttpMime(program.port, program.dir, program.url, program.livereload, program.watchFiles, !program.disableBrowserOpen);
+simpleHttpMime(program.port, program.dir, program.url, program.livereload, program.watchFiles, !program.disableBrowserOpen, +program.debounceDelay);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "connect": "^3.4.1",
     "connect-livereload": "^0.5.4",
     "gaze": "^1.1.0",
+    "lodash.debounce": "^4.0.8",
     "open": "0.0.5",
     "serve-index": "^1.8.0",
     "serve-static": "^1.11.1",

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ module.exports = function(port, dir, url, livereloadPort, watchFiles, openBrowse
       var changed = debounce(function() {
         console.log("Sending changes:\n\t%s", files.join("\n\t"));
         livereloadServer.changed({body:{files:files}});
-        files.length = 0;
+        files = [];
       }, debounceDelay);
       this.on('all', function(event, filepath) {
         console.log("Watch: " + filepath + ' was ' + event);


### PR DESCRIPTION
We've been using `lr-http-server` to serve our static site, but while we are building/watching our directory there can be multiple file changes at (nearly) the same time which leads basically having this blinking page because livereload tries to send all the changes after each other (css, html, javascript).

So I added a new option which can be passed to lr-http-server to configure on how often it should emit the changed files list. If you omit it, it will be set to zero which means it will list the changed files at [`process.nextTick`](https://lodash.com/docs/4.16.1#debounce).